### PR TITLE
Ensure pickmdl::x13_text_frame works with :: calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pickmdl
 Type: Package
 Title: PICKMDL for RJDemetra
-Version: 0.6.6
-Date: 2025-04-08
+Version: 0.6.7
+Date: 2025-10-27
 Authors@R: c(person("Øyvind", "Langsrud", role = c("aut", "cre"), email = "oyl@ssb.no"),
              person("Dinh Quang", "Pham", role = c("aut")),
              person("Ane", "Seierstad", role = c("aut")),
@@ -17,7 +17,7 @@ Description: PICKMDL for RJDemetra.
 License: MIT + file LICENSE
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/x13_text_frame.R
+++ b/R/x13_text_frame.R
@@ -45,8 +45,8 @@ x13_text_frame <- function(text_frame, series = NULL, id = NULL, ..., drop = TRU
       dots2list <- FALSE
       warning("dots2list ignored since ... used to call x13_text_frame")
     } else {
-      # `deparse(as.name(` included for old r version where character string needed. 
-      sys_call <- sys_call[!names(sys_call) %in% names(formals(get(deparse(as.name(sys_call[[1]])))))]
+      fml_names <- names(formals(x13_text_frame))
+      sys_call <- sys_call[!names(sys_call) %in% fml_names]
       sys_call <- as.list(sys_call)[-1]
       sys_call <- sys_call[names(sys_call) != ""]
     }


### PR DESCRIPTION
Replaced indirect lookup using sys_call[[1]] with a direct reference to x13_text_frame. The function name is fixed, so this approach is simpler, more robust, and works correctly when called via :: or :::.

+ new Version, Date and RoxygenNote